### PR TITLE
fix(rust): don't use `keys` LazyKeys handlers but instead `on_attach`…

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -48,12 +48,26 @@ return {
     "mrcjkb/rustaceanvim",
     version = "^3", -- Recommended
     ft = { "rust" },
-    keys = {
-      { "<leader>cR", function() vim.cmd.RustLsp("codeAction") end, desc = "Code Action" },
-      { "<leader>dr", function() vim.cmd.RustLsp("debuggables") end, desc = "Rust debuggables" },
-    },
     opts = {
       server = {
+        on_attach = function(_, bufnr)
+          -- register which-key mappings
+          local wk = require("which-key")
+          wk.register({
+            ["<leader>cR"] = {
+              function()
+                vim.cmd.RustLsp("codeAction")
+              end,
+              "Code Action",
+            },
+            ["<leader>dr"] = {
+              function()
+                vim.cmd.RustLsp("debuggables")
+              end,
+              "Rust debuggables",
+            },
+          }, { mode = "n", buffer = bufnr })
+        end,
         settings = {
           -- rust-analyzer language server configuration
           ["rust-analyzer"] = {
@@ -78,13 +92,11 @@ return {
             },
           },
         },
-      }
+      },
     },
     config = function(_, opts)
-      vim.g.rustaceanvim = vim.tbl_deep_extend("force",
-        {},
-        opts or {})
-    end
+      vim.g.rustaceanvim = vim.tbl_deep_extend("force", {}, opts or {})
+    end,
   },
 
   -- Correctly setup lspconfig for Rust 🚀
@@ -129,5 +141,4 @@ return {
       },
     },
   },
-
 }

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -48,6 +48,10 @@ return {
     "mrcjkb/rustaceanvim",
     version = "^3", -- Recommended
     ft = { "rust" },
+    keys = {
+      { "<leader>cR", function() vim.cmd.RustLsp("codeAction") end, desc = "Code Action" },
+      { "<leader>dr", function() vim.cmd.RustLsp("debuggables") end, desc = "Rust debuggables" },
+    },
     opts = {
       server = {
         settings = {
@@ -77,19 +81,9 @@ return {
       }
     },
     config = function(_, opts)
-      vim.g.rustaceanvim = vim.tbl_deep_extend("force", {
-        -- LSP configuration
-        server = {
-          on_attach = function(client, bufnr)
-            -- register which-key mappings
-            local wk = require("which-key")
-            wk.register({
-              ["<leader>cR"] = { function() vim.cmd.RustLsp("codeAction") end, "Code Action" },
-              ["<leader>dr"] = { function() vim.cmd.RustLsp("debuggables") end, "Rust debuggables" },
-            }, { mode = "n", buffer = bufnr })
-          end,
-        },
-      }, opts or {})
+      vim.g.rustaceanvim = vim.tbl_deep_extend("force",
+        {},
+        opts or {})
     end
   },
 

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -48,8 +48,36 @@ return {
     "mrcjkb/rustaceanvim",
     version = "^3", -- Recommended
     ft = { "rust" },
+    opts = {
+      server = {
+        settings = {
+          -- rust-analyzer language server configuration
+          ["rust-analyzer"] = {
+            cargo = {
+              allFeatures = true,
+              loadOutDirsFromCheck = true,
+              runBuildScripts = true,
+            },
+            -- Add clippy lints for Rust.
+            checkOnSave = {
+              allFeatures = true,
+              command = "clippy",
+              extraArgs = { "--no-deps" },
+            },
+            procMacro = {
+              enable = true,
+              ignored = {
+                ["async-trait"] = { "async_trait" },
+                ["napi-derive"] = { "napi" },
+                ["async-recursion"] = { "async_recursion" },
+              },
+            },
+          },
+        },
+      }
+    },
     config = function(_, opts)
-      vim.g.rustaceanvim = {
+      vim.g.rustaceanvim = vim.tbl_deep_extend("force", {
         -- LSP configuration
         server = {
           on_attach = function(client, bufnr)
@@ -60,32 +88,8 @@ return {
               ["<leader>dr"] = { function() vim.cmd.RustLsp("debuggables") end, "Rust debuggables" },
             }, { mode = "n", buffer = bufnr })
           end,
-          settings = {
-            -- rust-analyzer language server configuration
-            ["rust-analyzer"] = {
-              cargo = {
-                allFeatures = true,
-                loadOutDirsFromCheck = true,
-                runBuildScripts = true,
-              },
-              -- Add clippy lints for Rust.
-              checkOnSave = {
-                allFeatures = true,
-                command = "clippy",
-                extraArgs = { "--no-deps" },
-              },
-              procMacro = {
-                enable = true,
-                ignored = {
-                  ["async-trait"] = { "async_trait" },
-                  ["napi-derive"] = { "napi" },
-                  ["async-recursion"] = { "async_recursion" },
-                },
-              },
-            },
-          },
         },
-      }
+      }, opts or {})
     end
   },
 


### PR DESCRIPTION
… of `rustaceanvim` for keymaps. 
This change avoids making the keymaps available as `LazyKeys` handlers to the user to lazy-load
the plugin. 

As I mentioned in the LazyVim PR you created, the user is able to press the keymaps even in a 
non-rust file and the plugin was loaded as seen in the Lazy UI (even though nothing happened because
of an error about the command since `rust-analyzer` wasn't attached).

I really hope I'm not overstepping any boundaries. If you prefer any kind of interaction being strictly
confined in the LazyVim PRs in the future, please do tell me. I took the initiative to make this PR in 
your branch, because I didn't want to look like I was nitpicking at your PR with my comments expecting 
you to do all the work. After all I have absolutely no experience with Rust. Just a bit of experience with
configuring my own LazyVim.